### PR TITLE
ISSUE-4 - Markers don't work on iOS

### DIFF
--- a/Bus.js
+++ b/Bus.js
@@ -54,7 +54,8 @@ class Bus extends Component {
             <Marker coordinate={coordinate}
                     onPress={this.props.onOpen}
                     onCalloutPress={this.props.onClose}
-                >
+                    >
+                { /*
                 <View renderKey={this.state.key}>
                     <Callout style={styles.callout}>
                         <View style={styles.row}>
@@ -87,6 +88,8 @@ class Bus extends Component {
                         }
                     </Callout>
                 </View>
+                  */
+                    }
             </Marker>
         );
     }

--- a/Route.js
+++ b/Route.js
@@ -90,14 +90,12 @@ class Route extends Component {
                 );
             });
 
-            return (
-                <View>
-                    {polylines}
-                    {buses}
-                </View>
-            );
+            return [
+                polylines,
+                buses
+            ];
         } else {
-            return (<View>{buses}</View>);
+            return buses;
         }
     }
 }


### PR DESCRIPTION
This resolves #4. There were problems with rendering the Buses inside an empty View. Interestingly, this caused rendering to not work using react-native-maps with both Apple Maps AND Google Maps. It also caused issues with react-native-mapbox-gl!

There appear to be some issues rendering callouts. I have temporarily commented them out for now. I haven't decided whether they should be resolved in this ticket in a separate one.